### PR TITLE
Loading Screen Fix On Going Back to Form

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,17 @@
     <link rel="stylesheet" href="css/custom.css">
     <link rel="stylesheet" href="css/formbold.css">
     <script>
+        window.addEventListener("pageshow", (event) => {
+            if (event.persisted) {
+                hideSpinnerAndMessage();
+            }
+        });
+
+        function hideSpinnerAndMessage() {
+            document.getElementById('donation-page').style.display = "block";
+            document.getElementById('loading-element').style.display = "none";
+        }
+
         const form = document.getElementById('weborder');
 
         form.addEventListener('submit', (e) => {


### PR DESCRIPTION
When links on my page are clicked, a spinner and a message appear on the page. It works, and they disappear appropriately when the new page is loaded in.

I found a bug though. When a user clicks the back button on their browser, it goes back to the previous page, but in the state of displaying the spinner and error message. I want to of course go back to the state where the message is hidden and the spinner is not showing.

This code fixes it.